### PR TITLE
Add .gitattributes, Travis and Scrutinizer configurations

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+docker              export-ignore
 .gitattributes      export-ignore
 .gitignore          export-ignore
 .travis.yml         export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.travis.yml         export-ignore
+.scrutinizer.yml    export-ignore
+phpunit.xml.dist    export-ignore
+tests               export-ignore

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,10 @@
+tools:
+  external_code_coverage: true
+
+  php_code_sniffer:
+    config:
+      standard: "PSR2"
+
+filter:
+  excluded_paths:
+    - tests/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: php
+sudo: false
+
+matrix:
+  include:
+    - php: 7.1
+      env: 
+        - TEST_COVERAGE=true
+    - php: 7.1
+      env: 
+        - COMPOSER_OPTIONS="--prefer-lowest"
+  fast_finish: true
+
+install:
+  - if [[ ! $TEST_COVERAGE ]]; then phpenv config-rm xdebug.ini; fi
+  - if [[ $TEST_COVERAGE ]]; then PHPUNIT_FLAGS="--coverage-clover ./build/logs/clover.xml"; fi
+  - composer update --prefer-dist --prefer-stable --no-interaction $COMPOSER_OPTIONS
+
+script:
+  - bin/phpunit -v $PHPUNIT_FLAGS
+
+after_success:
+  - if [[ $TEST_COVERAGE ]]; then wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover ./build/logs/clover.xml; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   - composer update --prefer-dist --prefer-stable --no-interaction $COMPOSER_OPTIONS
 
 script:
-  - bin/phpunit -v $PHPUNIT_FLAGS
+  - vendor/bin/phpunit -v $PHPUNIT_FLAGS
 
 after_success:
   - if [[ $TEST_COVERAGE ]]; then wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover ./build/logs/clover.xml; fi

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# validoo
+# facile-it/validoo
+
+[![Stable release][Last stable image]][Packagist link]
+[![Unstable release][Last unstable image]][Packagist link]
+[![Build status][Master build image]][Master build link]
+[![Coverage Status][Master coverage image]][Master coverage link]
+[![Scrutinizer][Master scrutinizer image]][Master scrutinizer link]
+
+[Last stable image]: https://poser.pugx.org/facile-it/validoo/version.svg
+[Last unstable image]: https://poser.pugx.org/facile-it/validoo/v/unstable.svg
+[Master build image]: https://travis-ci.org/facile-it/validoo.svg
+[Master scrutinizer image]: https://scrutinizer-ci.com/g/facile-it/validoo/badges/quality-score.png?b=master
+[Master coverage image]: https://scrutinizer-ci.com/g/facile-it/validoo/badges/coverage.png?b=master
+
+[Packagist link]: https://packagist.org/packages/facile-it/validoo
+[Master build link]: https://travis-ci.org/facile-it/validoo
+[Master scrutinizer link]: https://scrutinizer-ci.com/g/facile-it/validoo/?branch=master
+[Master coverage link]: https://scrutinizer-ci.com/g/facile-it/validoo/?branch=master

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,39 @@
+FROM php:7.1
+
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+RUN apt-get update
+RUN apt-get install -y curl \
+    git \
+    zsh \
+    ssh \
+    supervisor \
+    sudo \
+    nano \
+ ## PHP-EXT
+    libzip-dev \
+    && docker-php-ext-install -j5 zip mbstring \
+    && apt-get clean
+
+COPY config/sudoers /etc/sudoers
+COPY config/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+COPY config/php.ini /usr/local/etc/php/conf.d/
+
+#COMPOSER
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+WORKDIR /usr/local/bin
+
+RUN useradd -ms /bin/zsh validoo
+RUN usermod -aG sudo validoo
+USER validoo
+
+WORKDIR /home/validoo/project
+
+#Zsh minimal installation
+RUN git clone --depth=1 git://github.com/robbyrussell/oh-my-zsh.git  ~/.oh-my-zsh \
+    && sudo chsh -s /bin/zsh
+ADD config/.zshrc /root/
+ADD config/.zshrc /home/validoo/
+
+ENV TERM xterm-256color
+CMD sudo /usr/bin/supervisord

--- a/docker/config/.zshrc
+++ b/docker/config/.zshrc
@@ -1,0 +1,79 @@
+# Path to your oh-my-zsh installation.
+export ZSH=$HOME/.oh-my-zsh
+
+# Set name of the theme to load.
+# Look in ~/.oh-my-zsh/themes/
+# Optionally, if you set this to "random", it'll load a random theme each
+# time that oh-my-zsh is loaded.
+ZSH_THEME="ys"
+
+# Uncomment the following line to use case-sensitive completion.
+# CASE_SENSITIVE="true"
+
+# Uncomment the following line to disable bi-weekly auto-update checks.
+# DISABLE_AUTO_UPDATE="true"
+
+# Uncomment the following line to change how often to auto-update (in days).
+# export UPDATE_ZSH_DAYS=13
+
+# Uncomment the following line to disable colors in ls.
+# DISABLE_LS_COLORS="true"
+
+# Uncomment the following line to disable auto-setting terminal title.
+# DISABLE_AUTO_TITLE="true"
+
+# Uncomment the following line to enable command auto-correction.
+# ENABLE_CORRECTION="true"
+
+# Uncomment the following line to display red dots whilst waiting for completion.
+# COMPLETION_WAITING_DOTS="true"
+
+# Uncomment the following line if you want to disable marking untracked files
+# under VCS as dirty. This makes repository status check for large repositories
+# much, much faster.
+# DISABLE_UNTRACKED_FILES_DIRTY="true"
+
+# Uncomment the following line if you want to change the command execution time
+# stamp shown in the history command output.
+# The optional three formats: "mm/dd/yyyy"|"dd.mm.yyyy"|"yyyy-mm-dd"
+# HIST_STAMPS="mm/dd/yyyy"
+
+# Would you like to use another custom folder than $ZSH/custom?
+# ZSH_CUSTOM=/path/to/new-custom-folder
+
+# Which plugins would you like to load? (plugins can be found in ~/.oh-my-zsh/plugins/*)
+# Custom plugins may be added to ~/.oh-my-zsh/custom/plugins/
+# Example format: plugins=(rails git textmate ruby lighthouse)
+# Add wisely, as too many plugins slow down shell startup.
+plugins=(git symfony2 phing)
+
+# User configuration
+
+export PATH="/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games:/home/validoo/project/vendor/bin"
+
+source $ZSH/oh-my-zsh.sh
+
+# You may need to manually set your language environment
+# export LANG=en_US.UTF-8
+
+# Preferred editor for local and remote sessions
+# if [[ -n $SSH_CONNECTION ]]; then
+#   export EDITOR='vim'
+# else
+#   export EDITOR='mvim'
+# fi
+
+# Compilation flags
+# export ARCHFLAGS="-arch x86_64"
+
+# ssh
+# export SSH_KEY_PATH="~/.ssh/dsa_id"
+
+# Set personal aliases, overriding those provided by oh-my-zsh libs,
+# plugins, and themes. Aliases can be placed here, though oh-my-zsh
+# users are encouraged to define aliases within the ZSH_CUSTOM folder.
+# For a full list of active aliases, run `alias`.
+#
+# Example aliases
+# alias zshconfig="mate ~/.zshrc"
+# alias ohmyzsh="mate ~/.oh-my-zsh"

--- a/docker/config/php.ini
+++ b/docker/config/php.ini
@@ -1,0 +1,4 @@
+[PHP]
+
+[Date]
+date.timezone = Europe/Rome

--- a/docker/config/sudoers
+++ b/docker/config/sudoers
@@ -1,0 +1,27 @@
+#
+# This file MUST be edited with the 'visudo' command as root.
+#
+# Please consider adding local content in /etc/sudoers.d/ instead of
+# directly modifying this file.
+#
+# See the man page for details on how to write a sudoers file.
+#
+Defaults	env_reset
+Defaults	mail_badpass
+Defaults	secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+# Host alias specification
+
+# User alias specification
+
+# Cmnd alias specification
+
+# User privilege specification
+root	ALL=(ALL:ALL) ALL
+
+# Allow members of group sudo to execute any command
+%sudo	ALL=(ALL:ALL) NOPASSWD: ALL
+
+# See sudoers(5) for more information on "#include" directives:
+
+#includedir /etc/sudoers.d

--- a/docker/config/supervisord.conf
+++ b/docker/config/supervisord.conf
@@ -1,0 +1,2 @@
+[supervisord]
+nodaemon=true

--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+docker build -t validoo_image $DIR
+
+docker rm -f validoo_container || echo "Previous container not found"
+docker run -d -v $DIR/../:/home/validoo/project --name validoo_container -ti validoo_image bash
+
+sleep 1
+
+docker exec -ti -u validoo validoo_container zsh

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,29 @@
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+        >
+    <php>
+        <ini name="error_reporting" value="-1"/>
+        <ini name="intl.default_locale" value="en"/>
+        <ini name="intl.error_level" value="0"/>
+        <ini name="memory_limit" value="-1"/>
+    </php>
+
+    <testsuites>
+        <testsuite name="default">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src/Validoo/</directory>
+            <exclude>
+                <directory>./src/Validoo/errors</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+
+</phpunit>


### PR DESCRIPTION
This PR is to add external integrations to run tests and collect code coverage, plus additional stuff:
 * Travis integration, to run tests and produce coverage
 * Scrutinizer, to watch CS, collect coverage and detect issues
 * .gitattributes, to strip unused files when distributed through Composer

Please add the Travis and Scrutinizer service hooks before merging, so we can test the PR integration.
